### PR TITLE
Fix for drilldown in case of more then one element on axis 1

### DIFF
--- a/src/factories/baseWidget.js
+++ b/src/factories/baseWidget.js
@@ -689,7 +689,9 @@
                     mdx = mdx.replace(str, (isNonEmpty ? "NON EMPTY " : " ") + path + " ");
                 }
 
-                if ((!customDrill && customDrills.length !== 0) || (customDrills.length === 0)) {
+                if (((!customDrill && customDrills.length !== 0) || (customDrills.length === 0))
+                    // if on exis 1 there are more than one element then skip
+                    && (!mdx.match(/\{.*\} ON 1/))){
                     var idx = mdx.indexOf(".Members ON 1 FROM");
                     if (idx === -1) {
                         mdx = mdx.replace(" ON 1 FROM", " .children ON 1 FROM");
@@ -1317,7 +1319,7 @@
                         }
                     }
                 }
-                
+
                 for (i = 0; i < _this.filterCount; i++) {
                     flt = _this.getFilter(i);
                     if (flt.isInterval) {


### PR DESCRIPTION
When there are more then one element on axis 1 next code adds " .children" which brokes mdx
```
if (((!customDrill && customDrills.length !== 0) || (customDrills.length === 0)) {
    var idx = mdx.indexOf(".Members ON 1 FROM");
    if (idx === -1) {
        mdx = mdx.replace(" ON 1 FROM", " .children ON 1 FROM");
    } else {
        mdx = mdx.replace(".Members ON 1 FROM", "." + path.split('.').pop() + ".children ON 1 FROM");
    }
    return mdx;
}
```
Example of of mdx which modifies incorrectly

```
SELECT 
  {[Measures].[Baburin],[Measures].[Grudinin],[Measures].[Putin],
  [Measures].[Sobchak],[Measures].[Suraykin],[Measures].[Titov],
  [Measures].[Yavlinsky],[Measures].[Zhirinovsky]} ON 1 
FROM [ELECTIONS2018CUBE] 
%FILTER %OR({[Territory].[H1].[Subregion].&[Красносельский район] })
```