### PR TITLE
Fix #131: Don't encode login/password

### DIFF
--- a/src/services/connector.js
+++ b/src/services/connector.js
@@ -413,7 +413,7 @@
                 url: url ? (url + 'Test?Namespace=' + namespace) : (_this.url + 'Test?Namespace=' + namespace),
                 timeout: CONST.timeout,
                 headers: {
-                    'Authorization': 'Basic ' + btoa(encodeURIComponent(login) + ":" + encodeURIComponent(password))
+                    'Authorization': 'Basic ' + btoa(login + ":" + password)
                 }
             }).then(transformResponse);
         }


### PR DESCRIPTION
Previously, authentication failures would result if login/password contained characters that needed to be URI-encoded.